### PR TITLE
Fixing build issues on clean RedHat 7 with openblas and lapack installed.

### DIFF
--- a/include/lapacke_mangling.h
+++ b/include/lapacke_mangling.h
@@ -1,0 +1,17 @@
+#ifndef LAPACK_HEADER_INCLUDED
+#define LAPACK_HEADER_INCLUDED
+
+#ifndef LAPACK_GLOBAL
+#if defined(LAPACK_GLOBAL_PATTERN_LC) || defined(ADD_)
+#define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
+#elif defined(LAPACK_GLOBAL_PATTERN_UC) || defined(UPPER)
+#define LAPACK_GLOBAL(lcname,UCNAME)  UCNAME
+#elif defined(LAPACK_GLOBAL_PATTERN_MC) || defined(NOCHANGE)
+#define LAPACK_GLOBAL(lcname,UCNAME)  lcname
+#else
+#define LAPACK_GLOBAL(lcname,UCNAME)  lcname##_
+#endif
+#endif
+
+#endif
+

--- a/src/Makefile
+++ b/src/Makefile
@@ -15,11 +15,11 @@ endif
 ifdef OPENBLAS
 CFLAGS  = -I../include -I$(OPENBLAS)/include -D_GNU_SOURCE
 LDFLAGS = -L$(OPENBLAS)/lib -D_GNU_SOURCE
-LDLIBS  = -Wl,-Bdynamic -lgsl -Wl,-Bstatic -lopenblas -Wl,-Bdynamic -lgfortran -pthread -lm
+LDLIBS  = -Wl,-Bdynamic -lgsl -Wl,-Bstatic -lopenblas -Wl,-Bdynamic -lgfortran -pthread -lm -llapacke
 else
 CFLAGS  = -I../include -D_GNU_SOURCE
 LDFLAGS = -D_GNU_SOURCE
-LDLIBS  = -lgsl -lopenblas -lgfortran -pthread -lm
+LDLIBS  = -lgsl -lopenblas -lgfortran -pthread -lm -llapacke
 endif
 
 CC = gcc


### PR DESCRIPTION
Fixes two issues when compiling the source on standard RedHat 7 with gcc 4.8.3 with openblas and lapack installed from repo.

GCC would complain that "lapacke_mangling.h" file, referenced by "lapacke.h" could not be found. This could be solved by either removing "lapacke.h" from include directory and relying on system wide header or by adding "lapacke_mangling.h" to include, which i did for the sake of compliance.

```
In file included from ksrc/kjg_gsl.c:10:0:
../include/lapacke.h:143:30: fatal error: lapacke_mangling.h: No such file or directory
 #include "lapacke_mangling.h"
                              ^
compilation terminated.
```

Also, GCC linker would not find lapack functions without "-llapacke" flag passed to linker cmd.

```
gcc -L/opt/openblas/lib -D_GNU_SOURCE  eigensrc/smartpca.o eigensrc/eigsubs.o eigensrc/exclude.o eigensrc/smartsubs.o eigensrc/eigx.o twsubs.o mcio.o qpsubs.o admutils.o egsubs.o regsubs.o gval.o nicksrc/libnick.a ksrc/kjg_fpca.o ksrc/kjg_gsl.o  -Wl,-Bdynamic -lgsl -Wl,-Bstatic -lopenblas -Wl,-Bdynamic -lgfortran -pthread -lm  -o eigensrc/smartpca
ksrc/kjg_gsl.o: In function `kjg_gsl_dlange':
kjg_gsl.c:(.text+0x4c5): undefined reference to `LAPACKE_dlange'
ksrc/kjg_gsl.o: In function `kjg_gsl_dgeqrf':
kjg_gsl.c:(.text+0x526): undefined reference to `LAPACKE_dgeqrf'
ksrc/kjg_gsl.o: In function `kjg_gsl_dorgqr':
kjg_gsl.c:(.text+0x585): undefined reference to `LAPACKE_dorgqr'
ksrc/kjg_gsl.o: In function `kjg_gsl_SVD':
kjg_gsl.c:(.text+0x88d): undefined reference to `LAPACKE_dgesvd'
collect2: error: ld returned 1 exit status
```
