### PR TITLE
Fix undefined symbols during linking.

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 override CFLAGS += -I../include -I/usr/include/openblas
 #LDLIBS += -lgsl -lopenblas -lrt -lm
-override LDLIBS += -lgsl -lopenblas -lm -lpthread
+override LDLIBS += -lgsl -lopenblas -lm -lpthread -llapacke
 
 ifeq ($(OPTIMIZE), 1)
 	CFLAGS += -O2


### PR DESCRIPTION
The attached patch fixes undefined symbol errors during linking on Linux Mint 18:

    $ make
    #cp smshrink.o smshrink
    cc   eigensrc/smartpca.o eigensrc/eigsubs.o eigensrc/exclude.o eigensrc/smartsubs.o eigensrc/eigx.o mcio.o qpsubs.o admutils.o egsubs.o regsubs.o gval.o nicksrc/libnick.a ksrc/kjg_fpca.o ksrc/kjg_gsl.o  -lgsl -lopenblas -lm -lpthread  -o eigensrc/smartpca
    ksrc/kjg_gsl.o: In function `kjg_gsl_dlange':
    kjg_gsl.c:(.text+0x4d2): undefined reference to `LAPACKE_dlange'
    ksrc/kjg_gsl.o: In function `kjg_gsl_dgeqrf':
    kjg_gsl.c:(.text+0x532): undefined reference to `LAPACKE_dgeqrf'
    ksrc/kjg_gsl.o: In function `kjg_gsl_dorgqr':
    kjg_gsl.c:(.text+0x598): undefined reference to `LAPACKE_dorgqr'
    ksrc/kjg_gsl.o: In function `kjg_gsl_SVD':
    kjg_gsl.c:(.text+0x88b): undefined reference to `LAPACKE_dgesvd'
    collect2: error: ld returned 1 exit status
    <builtin>: recipe for target 'eigensrc/smartpca' failed
    make: *** [eigensrc/smartpca] Error 1
