### PR TITLE
Fix build for OSX-arm64

### DIFF
--- a/src/admutils.c
+++ b/src/admutils.c
@@ -537,7 +537,7 @@ testnan (double *a, int n)
   int i;
 
   for (i = 0; i < n; i++) {
-    if (!finite (a[i]))
+    if (!isfinite (a[i]))
       fatalx ("(testnan) fails:  index %d\n", i);
   }
 }

--- a/src/nicksrc/Makefile
+++ b/src/nicksrc/Makefile
@@ -1,4 +1,4 @@
-override CFLAGS += -c -O3   -g -p -Wimplicit -I../../include
+override CFLAGS += -c -O3  -g -Wimplicit -I../../include
 
 all: libnick.a
 


### PR DESCRIPTION
With these fixes Eigensoft can also bei installed on OSX-arm64.

Two issues prevent this so far:
1. The `finite` function is obsolete and should be replaced with `isfinite` (see https://linux.die.net/man/3/finite). It seems that this was done in many cases, but missed in one. 
2. The compiler option `-p` seems to be invalid for the apple clang compiler, as far as I understand this flag is also not required for other platforms for the normal execution mode of e.g. smartpca (as it is a profiling flag?).